### PR TITLE
chore: add go binary release ci

### DIFF
--- a/.github/workflows/push_binary.yaml
+++ b/.github/workflows/push_binary.yaml
@@ -1,0 +1,36 @@
+name: Go Release Action
+on:
+  release:
+    types: [created]
+
+permissions:
+    contents: write
+    packages: write
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64, arm64]
+        exclude:
+          - goarch: "386"
+            goos: darwin
+          - goarch: arm64
+            goos: windows
+    steps:
+    - uses: actions/checkout@v4
+    - uses: wangyoucao577/go-release-action@v1.42
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        project_path: "./cmd/prel/"
+        binary_name: "prel"
+        extra_files: LICENSE README.md
+        build_flags: "-trimpath"
+        ldflags: "-s -w"
+        asset_name: "prel-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"


### PR DESCRIPTION
add go binary in release page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated release process for Go binary across Linux, Windows, and macOS platforms upon new release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->