### PR TITLE
Change API.yaml and oas_validators_gen.go: Changed the maxLength of notificationMessage from 100 to 1000. Change admin_setting.tpl: Changed the maxLength of notification-message from 100 to 1000.

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -798,10 +798,10 @@ paths:
               properties:
                 notificationMessageForRequest:
                   type: string
-                  maxLength: 100
+                  maxLength: 1000
                 notificationMessageForJudge:
                   type: string
-                  maxLength: 100
+                  maxLength: 1000
       responses:
         "204":
           description: success

--- a/api/prel_api/oas_validators_gen.go
+++ b/api/prel_api/oas_validators_gen.go
@@ -272,7 +272,7 @@ func (s *APISettingsPatchReq) Validate() error {
 				if err := (validate.String{
 					MinLength:    0,
 					MinLengthSet: false,
-					MaxLength:    100,
+					MaxLength:    1000,
 					MaxLengthSet: true,
 					Email:        false,
 					Hostname:     false,
@@ -298,7 +298,7 @@ func (s *APISettingsPatchReq) Validate() error {
 				if err := (validate.String{
 					MinLength:    0,
 					MinLengthSet: false,
-					MaxLength:    100,
+					MaxLength:    1000,
 					MaxLengthSet: true,
 					Email:        false,
 					Hostname:     false,

--- a/web/template/templates/admin_setting.tpl
+++ b/web/template/templates/admin_setting.tpl
@@ -20,7 +20,7 @@
 						<td>Request Notification Message</td>
 						<td>
 							<textarea
-								maxlength="100"
+								maxlength="1000"
 								class="form-control"
 								id="notification-message-for-request"
 								rows="3">{{.AdminSettingPage.NotificationMessageForRequest}}</textarea>
@@ -37,7 +37,7 @@
 						<td>Judge Notification Message</td>
 						<td>
 							<textarea
-								maxlength="100"
+								maxlength="1000"
 								class="form-control"
 								id="notification-message-for-judge"
 								rows="3">{{.AdminSettingPage.NotificationMessageForJudge}}</textarea>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Increased the maximum length for notification messages for requests and judgments from 100 to 1000 characters, allowing for more detailed communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->